### PR TITLE
스프링 컨테이너에 등록된 빈 확인용 테스트 코드 작성

### DIFF
--- a/src/test/java/hello/core/beanfind/ApplicationContextInfoTest.java
+++ b/src/test/java/hello/core/beanfind/ApplicationContextInfoTest.java
@@ -1,0 +1,41 @@
+package hello.core.beanfind;
+
+import hello.core.AppConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+public class ApplicationContextInfoTest {
+
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+    @Test
+    @DisplayName("모든 빈 출력하기")
+    void findAllBean() {
+        String[] beanDefinitionNames = ac.getBeanDefinitionNames();
+        for (String beanDefinitionName : beanDefinitionNames) {
+            Object bean = ac.getBean(beanDefinitionName);
+            System.out.println("name = " + beanDefinitionName + " object = " + bean);
+
+        }
+    }
+
+    @Test
+    @DisplayName("애플리케이션 빈 출력하기")
+    void findApplicationBean() {
+        String[] beanDefinitionNames = ac.getBeanDefinitionNames();
+        for (String beanDefinitionName : beanDefinitionNames) {
+            BeanDefinition beanDefinition = ac.getBeanDefinition(beanDefinitionName);
+
+            // 내가 app 개발을 위해 등록한 bean 인지 검사
+            // Role ROLE_APPLICATION: 직접 등록한 애플리케이션 빈
+            // Role ROLE_INFRASTRUCTURE 스프링 내뷍서 사용하는
+            if (beanDefinition.getRole() == BeanDefinition.ROLE_APPLICATION) {
+                Object bean = ac.getBean(beanDefinitionName);
+                System.out.println("name = " + beanDefinitionName + " object = " + bean);
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
- 모든 빈 출력하기 findAllBean
      - ac.getBeanDefinitionNames() : 스프링에 등록된 모든 빈 이름 조회
      - ac.getBean() : 빈 이름으로 빈 객체(인스턴스) 조회
- 애플리케이션 빈 출력하기 findApplicationBean
    - 스프링이 내부에서 사용하는 빈은 getRole() 로 구분할 수 있다.
        - ROLE_APPLICATION : 일반적으로 사용자가 정의한 빈
        - ROLE_INFRASTRUCTURE : 스프링이 내부에서 사용하는 빈